### PR TITLE
Extract major version of less before verifying

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -44,7 +44,7 @@ func ClearScreen() {
 	_ = c.Run()
 }
 
-func VerifyLessVersion(minimumVersion int) (isValid bool, currentVersion int) {
+func VerifyLessVersion(minimumVersion int) (isValid bool, currentVersion string) {
 	lessVersionInfo := getLessVersionInfo()
 
 	lessVersionInfoWords := strings.Fields(lessVersionInfo)
@@ -52,12 +52,12 @@ func VerifyLessVersion(minimumVersion int) (isValid bool, currentVersion int) {
 		panic("Could not parse less version info")
 	}
 
-	lessVersion, err := strconv.Atoi(lessVersionInfoWords[1])
+	lessVersion, err := strconv.ParseFloat(lessVersionInfoWords[1], 64)
 	if err != nil {
 		panic(err)
 	}
 
-	return lessVersion >= minimumVersion, lessVersion
+	return int(lessVersion) >= minimumVersion, lessVersionInfoWords[1]
 }
 
 func getLessVersionInfo() string {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -130,7 +130,7 @@ func verifyLess(noLessVerify bool) {
 		clx := aurora.Magenta("clx").String()
 
 		fmt.Printf("Your version of %s is outdated\n\n", less)
-		fmt.Printf("Your version:     %d\n", currentLessVersion)
+		fmt.Printf("Your version:     %s\n", currentLessVersion)
 		fmt.Printf("Required version: %d\n\n", app.MinimumLessVersion)
 		fmt.Printf("If you think this is an error, re-run %s with the %s flag to disable check", clx, flag)
 


### PR DESCRIPTION
At its current version, the verification process fails when someone is running a patched version of `less`. For eg. version 581.2

Though `less` doesn't usually ship versions like this but version 581.2 is the one that is installed by default on MacOS.

Current version of circumflex fails with an error as below,
```
panic: strconv.Atoi: parsing "581.2": invalid syntax

goroutine 1 [running]:
clx/cli.VerifyLessVersion(0x260)
	/home/runner/work/circumflex/circumflex/cli/cli.go:57 +0x78
clx/cmd.verifyLess(0xa1?)
	/home/runner/work/circumflex/circumflex/cmd/root.go:125 +0x28
clx/cmd.Root.func1(0x14000348600?, {0x103494948?, 0x0?, 0x0?})
	/home/runner/work/circumflex/circumflex/cmd/root.go:43 +0xfc
github.com/spf13/cobra.(*Command).execute(0x14000348600, {0x1400001e210, 0x0, 0x0})
	/home/runner/go/pkg/mod/github.com/spf13/cobra@v1.6.0/command.go:920 +0x5b0
github.com/spf13/cobra.(*Command).ExecuteC(0x14000348600)
	/home/runner/go/pkg/mod/github.com/spf13/cobra@v1.6.0/command.go:1040 +0x354
github.com/spf13/cobra.(*Command).Execute(...)
	/home/runner/go/pkg/mod/github.com/spf13/cobra@v1.6.0/command.go:968
main.main()
	/home/runner/work/circumflex/circumflex/main.go:9 +0x20
```

Signed-off-by: PrayagS <prayagsavsani@gmail.com>