### PR TITLE
Mark story as read when opening link

### DIFF
--- a/bubble/list/list.go
+++ b/bubble/list/list.go
@@ -536,6 +536,9 @@ func (m *Model) Update(msg tea.Msg) (*Model, tea.Cmd) {
 			return message.EditorFinishedMsg{Err: err}
 		})
 
+	case message.OpeningLink:
+		m.history.MarkAsReadAndWriteToDisk(msg.Id, msg.CommentCount)
+
 	case message.EnteringReaderMode:
 		errorMessage := validator.GetErrorMessage(msg.Title, msg.Domain)
 		if errorMessage != "" {
@@ -851,13 +854,18 @@ func (m *Model) handleBrowsing(msg tea.Msg) tea.Cmd {
 			if m.SelectedItem().URL == "" {
 				url := "https://news.ycombinator.com/item?id=" + strconv.Itoa(m.SelectedItem().ID)
 				browser.Open(url)
-
-				return nil
+			} else {
+				browser.Open(m.SelectedItem().URL)
 			}
 
-			browser.Open(m.SelectedItem().URL)
+			cmd := func() tea.Msg {
+				return message.OpeningLink{
+					Id:           m.SelectedItem().ID,
+					CommentCount: m.SelectedItem().CommentsCount,
+				}
+			}
 
-			return nil
+			return cmd
 
 		case msg.String() == "c":
 			url := "https://news.ycombinator.com/item?id=" + strconv.Itoa(m.SelectedItem().ID)

--- a/bubble/list/message/message.go
+++ b/bubble/list/message/message.go
@@ -14,6 +14,11 @@ type EnteringCommentSection struct {
 	CommentCount int
 }
 
+type OpeningLink struct {
+	Id           int
+	CommentCount int
+}
+
 type EnteringReaderMode struct {
 	Url    string
 	Title  string


### PR DESCRIPTION
Hi,

This PR adds the argument `--mark-read-on-open` to mark the items as read (write it in history) when opening a link.

Curious to have comments on this. On my side, it felt missing that the article was marked unread even though I did go through the article in my browser (not the comments, though).