### PR TITLE
Fix help page ghosting

### DIFF
--- a/bubble/list/list.go
+++ b/bubble/list/list.go
@@ -637,7 +637,7 @@ func (m *Model) updateHelpScreen(msg tea.Msg) (*Model, tea.Cmd) {
 		if k := msg.String(); k == "ctrl+c" || k == "q" || k == "esc" || k == "i" || k == "?" {
 			m.isOnHelpScreen = false
 
-			return m, nil
+			return m, tea.ClearScreen
 		}
 
 	case tea.WindowSizeMsg:

--- a/bubble/list/list.go
+++ b/bubble/list/list.go
@@ -964,16 +964,6 @@ func (m *Model) handleBrowsing(msg tea.Msg) tea.Cmd {
 	return tea.Batch(cmds...)
 }
 
-func (m *Model) showHelpScreen() tea.Cmd {
-	helpScreen := help.GetHelpScreen(m.config.EnableNerdFonts)
-
-	command := cli.Less(helpScreen, m.config)
-
-	return tea.ExecProcess(command, func(err error) tea.Msg {
-		return message.EditorFinishedMsg{Err: err}
-	})
-}
-
 // View renders the component.
 func (m *Model) View() string {
 	if m.isOnHelpScreen {


### PR DESCRIPTION
This fixes #131. I'm not entirely sure why this ghosting effect doesn't appear consistently on different terminal emulators but clearing the screen explicitly after exiting the help page seems to do this trick.

I also removed a function I found that's no longer being referenced while I was in the code.