### PR TITLE
Traversing pages more freely with up/down and j/k keybinds

### DIFF
--- a/bubble/list/list.go
+++ b/bubble/list/list.go
@@ -776,12 +776,26 @@ func (m *Model) handleBrowsing(msg tea.Msg) tea.Cmd {
 			return tea.Quit
 
 		case msg.String() == "up" || msg.String() == "k":
-			m.CursorUp()
+			if m.cursor == 0 && !m.Paginator.OnFirstPage() {
+        m.Paginator.PrevPage()
+        itemsOnPage := m.Paginator.ItemsOnPage(len(m.VisibleItems()))
+	  	  m.cursor = max(m.cursor, itemsOnPage - 1)
+        
+        return nil 
+      } 
+      m.CursorUp()
 
 			return nil
 
 		case msg.String() == "down" || msg.String() == "j":
-			m.CursorDown()
+      itemsOnPage := m.Paginator.ItemsOnPage(len(m.VisibleItems()))
+      if m.cursor == itemsOnPage - 1 && !m.Paginator.OnLastPage() {
+        m.Paginator.NextPage()
+        m.cursor = 0
+        
+        return nil
+      } 
+      m.CursorDown()
 
 			return nil
 


### PR DESCRIPTION
So, currently when list items are distributed across multiple pages you can not traverse these when ( cursorIndex == len(listItems) - 1 ) or ( cursorIndex == 0 ) is hit and the user is trying to go further down or up.

This is unusual behavior given that modern UIs allow for a more free item selection, especially in the context of similar applications. Let me know your thoughts on this or simply close if this is trivial :D 👍🏽
