### PR TITLE
Add pdf download - Fixes bensadeh/circumflex#140

### DIFF
--- a/bubble/list/list.go
+++ b/bubble/list/list.go
@@ -777,25 +777,25 @@ func (m *Model) handleBrowsing(msg tea.Msg) tea.Cmd {
 
 		case msg.String() == "up" || msg.String() == "k":
 			if m.cursor == 0 && !m.Paginator.OnFirstPage() {
-        m.Paginator.PrevPage()
-        itemsOnPage := m.Paginator.ItemsOnPage(len(m.VisibleItems()))
-	  	  m.cursor = max(m.cursor, itemsOnPage - 1)
-        
-        return nil 
-      } 
-      m.CursorUp()
+				m.Paginator.PrevPage()
+				itemsOnPage := m.Paginator.ItemsOnPage(len(m.VisibleItems()))
+				m.cursor = max(m.cursor, itemsOnPage-1)
+
+				return nil
+			}
+			m.CursorUp()
 
 			return nil
 
 		case msg.String() == "down" || msg.String() == "j":
-      itemsOnPage := m.Paginator.ItemsOnPage(len(m.VisibleItems()))
-      if m.cursor == itemsOnPage - 1 && !m.Paginator.OnLastPage() {
-        m.Paginator.NextPage()
-        m.cursor = 0
-        
-        return nil
-      } 
-      m.CursorDown()
+			itemsOnPage := m.Paginator.ItemsOnPage(len(m.VisibleItems()))
+			if m.cursor == itemsOnPage-1 && !m.Paginator.OnLastPage() {
+				m.Paginator.NextPage()
+				m.cursor = 0
+
+				return nil
+			}
+			m.CursorDown()
 
 			return nil
 

--- a/bubble/list/list.go
+++ b/bubble/list/list.go
@@ -776,12 +776,26 @@ func (m *Model) handleBrowsing(msg tea.Msg) tea.Cmd {
 			return tea.Quit
 
 		case msg.String() == "up" || msg.String() == "k":
-			m.CursorUp()
+			if m.cursor == 0 && !m.Paginator.OnFirstPage() {
+        m.Paginator.PrevPage()
+        itemsOnPage := m.Paginator.ItemsOnPage(len(m.VisibleItems()))
+	  	  m.cursor = max(m.cursor, itemsOnPage - 1)
+        
+        return nil 
+      } 
+      m.CursorUp()
 
 			return nil
 
 		case msg.String() == "down" || msg.String() == "j":
-			m.CursorDown()
+      itemsOnPage := m.Paginator.ItemsOnPage(len(m.VisibleItems()))
+      if m.cursor == itemsOnPage - 1 && !m.Paginator.OnLastPage() {
+        m.Paginator.NextPage()
+        m.cursor = 0
+        
+        return nil
+      } 
+      m.CursorDown()
 
 			return nil
 

--- a/bubble/list/list.go
+++ b/bubble/list/list.go
@@ -20,6 +20,7 @@ import (
 	"clx/bubble/ranking"
 	"clx/cli"
 	"clx/constants/category"
+	"clx/download"
 	"clx/favorites"
 	"clx/header"
 	"clx/help"
@@ -615,6 +616,21 @@ func (m *Model) Update(msg tea.Msg) (*Model, tea.Cmd) {
 		m.NewStatusMessage(msg.Message)
 
 		m.updatePagination()
+
+	case message.DownloadFile:
+		statusMessage := "Document downloaded successfully"
+		m.hideStatusMessage()
+		m.disableInput = false
+
+		filename, _ := download.GuessDownloadFileName(msg.Url)
+		downloadDir, _ := download.GetDownloadDir()
+		absoluteFilepath := fmt.Sprintf("%s/%s", downloadDir, filename)
+		err := download.DownloadFile(msg.Url, absoluteFilepath)
+		if err != nil {
+			statusMessage = "Could not download document"
+		}
+
+		return m, m.NewStatusMessageWithDuration(statusMessage, time.Second*3)
 	}
 
 	if m.isOnHelpScreen {
@@ -963,6 +979,23 @@ func (m *Model) handleBrowsing(msg tea.Msg) tea.Cmd {
 					CommentCount: m.SelectedItem().CommentsCount,
 				}
 			}
+
+		case msg.String() == "d":
+			if !strings.Contains(m.SelectedItem().Title, "[pdf]") {
+				return m.NewStatusMessage("Only PDFs are currently supported ...")
+			}
+			m.SetDisabledInput(true)
+
+			downloadCmd := func() tea.Msg {
+				return message.DownloadFile{
+					Url: m.SelectedItem().URL,
+				}
+			}
+
+			cmds = append(cmds, downloadCmd)
+			cmds = append(cmds, m.NewStatusMessage("Downloading ..."))
+
+			return tea.Batch(cmds...)
 		}
 	}
 

--- a/bubble/list/message/message.go
+++ b/bubble/list/message/message.go
@@ -63,3 +63,7 @@ type CategoryFetchingFinished struct {
 type AddToFavorites struct {
 	Item *item.Item
 }
+
+type DownloadFile struct {
+	Url string
+}

--- a/download/download.go
+++ b/download/download.go
@@ -1,0 +1,65 @@
+package download
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path"
+	"time"
+)
+
+const DownloadDir string = "circumflex/downloads"
+
+// Guess the PDF filename by extracting the last part of the download url
+func GuessDownloadFileName(url string) (string, error) {
+	absoluteFilepath := path.Base(url)
+
+	if absoluteFilepath == "." || absoluteFilepath == "/" {
+		return "", fmt.Errorf("Could not guess filename, potential invalid URL!")
+	}
+
+	return absoluteFilepath, nil
+}
+
+func GetDownloadDir() (string, error) {
+	dir, err := os.UserHomeDir()
+	if err != nil {
+		// If getting the current working directory fails as well,
+		// the user might have greater issues than simply downloading a file
+		dir, err = os.Getwd()
+		if err != nil {
+			return "", err
+		}
+	} else {
+		dir = fmt.Sprintf("%s/%s", dir, DownloadDir)
+	}
+
+	return dir, nil
+}
+
+// Writes to the destination file as it downloads it, without
+// loading the entire file into memory.
+func DownloadFile(url string, absoluteFilepath string) error {
+	out, err := os.Create(absoluteFilepath)
+	if err != nil {
+		return fmt.Errorf("Could not create file")
+	}
+	defer out.Close()
+
+	// Timeout download attempt after 10 seconds
+	client := http.Client{Timeout: 10 * time.Second}
+
+	resp, err := client.Get(url)
+	if err != nil {
+		return fmt.Errorf("Could not download file")
+	}
+	defer resp.Body.Close()
+
+	_, err = io.Copy(out, resp.Body)
+	if err != nil {
+		return fmt.Errorf("Could not write download file data to destination")
+	}
+
+	return nil
+}

--- a/info/info.go
+++ b/info/info.go
@@ -4,10 +4,12 @@ import (
 	"strings"
 
 	"clx/constants/nerdfonts"
+
 	. "github.com/logrusorgru/aurora/v3"
 
 	"clx/constants/margins"
 	"clx/keymaps"
+
 	text "github.com/MichaelMure/go-term-text"
 )
 
@@ -26,6 +28,7 @@ func GetText(screenWidth int, enableNerdFonts bool) string {
 	keys.AddKeymap("Open story link in browser", "o")
 	keys.AddKeymap("Open comments in browser", "c")
 	keys.AddSeparator()
+	keys.AddKeymap("Download article's document (only PDFs)", "d")
 	keys.AddKeymap("Add to favorites", "f")
 	keys.AddKeymap("Remove from favorites", "x")
 	keys.AddSeparator()


### PR DESCRIPTION
This push relies on a default file system location that will contain all downloaded PDFs, for now it is either '~/circumflex/downloads' or the current working directory of the running circumflex process, respectively.

The keybinding used here is "d" and blocks any input to the program until the download is complete. Information on the progress is given via the status message below the viewport. 