### PR TITLE
Feature/fetch comments exponential retries

### DIFF
--- a/hn/services/hybrid/hybrid.go
+++ b/hn/services/hybrid/hybrid.go
@@ -148,6 +148,7 @@ func (s *Service) FetchComments(id int) *item.Item {
 
 	for attempt := 1; attempt <= maxRetries; attempt++ {
 		client := resty.New()
+		// Increase timeout
 		client.SetTimeout(baseTimeout * time.Duration(attempt))
 		client.SetBaseURL("http://api.hackerwebapp.com/item/")
 
@@ -159,16 +160,14 @@ func (s *Service) FetchComments(id int) *item.Item {
 			break // Successful request
 		}
 
-		// Log error
-		fmt.Printf("Attempt %d failed: %v\n", attempt, err)
-
-		// Exponential backoff with jitter
+		// Exponential backoff with random jitter
 		jitter := time.Duration(rand.Intn(500)) * time.Millisecond
 		backoff := (1 << attempt) * time.Second
 		time.Sleep(backoff + jitter)
 	}
 
 	if err != nil {
+		// All attempts failed, log error 
 		fmt.Printf("Failed to fetch comments after %d retires: %w", maxRetries, err)
 	}
 

--- a/hn/services/hybrid/hybrid.go
+++ b/hn/services/hybrid/hybrid.go
@@ -6,6 +6,7 @@ import (
 	"strconv"
 	"sync/atomic"
 	"time"
+	"math/rand"
 
 	"github.com/bobesa/go-domain-util/domainutil"
 
@@ -138,15 +139,37 @@ func mapItem(hn *endpoints.HN) *item.Item {
 }
 
 func (s *Service) FetchComments(id int) *item.Item {
-	client := resty.New()
-	client.SetTimeout(5 * time.Second)
-	client.SetBaseURL("http://api.hackerwebapp.com/item/")
 
-	response, err := client.R().
-		SetHeader("User-Agent", app.Name+"/"+app.Version).
-		Get(strconv.Itoa(id))
+	baseTimeout := 5 * time.Second
+	maxRetries := 3
+
+	var response *resty.Response
+	var err error
+
+	for attempt := 1; attempt <= maxRetries; attempt++ {
+		client := resty.New()
+		client.SetTimeout(baseTimeout * time.Duration(attempt))
+		client.SetBaseURL("http://api.hackerwebapp.com/item/")
+
+
+		response, err = client.R().
+			SetHeader("User-Agent", app.Name+"/"+app.Version).
+			Get(strconv.Itoa(id))
+		if err == nil {
+			break // Successful request
+		}
+
+		// Log error
+		fmt.Printf("Attempt %d failed: %v\n", attempt, err)
+
+		// Exponential backoff with jitter
+		jitter := time.Duration(rand.Intn(500)) * time.Millisecond
+		backoff := (1 << attempt) * time.Second
+		time.Sleep(backoff + jitter)
+	}
+
 	if err != nil {
-		panic(err)
+		fmt.Printf("Failed to fetch comments after %d retires: %w", maxRetries, err)
 	}
 
 	sanitizedResponse := ansi.Strip(string(response.Body()))


### PR DESCRIPTION
Timeout for fetching comments was set to 5 seconds, which on a slowish connection sometimes lead to a
**timeout error (context deadline exceeded)** when entering comment section mode.

I have only encountered this on stories with a large amount of comments. I believe the timeout occurs because the function attempts to fetch all comments associated with the story at once, which can be too much for slower connections or stories with a lot of comments.

This PR adds retry logic with exponential backoff and random jitter to the FetchComments function to handle timeouts more gracefully. (5s, 10s, 15s) It retries the request with increasing delays if the server is slow to respond. If all retries fail, an error gets logged. Of course this can be seen as a local fix, maybe something larger is needed in the future in order to achieve a more comprehensive solution to error handling of this kind. At least it seems to have fixed the timeouts for me, and I have not seen it posted elsewhere. 