### PR TITLE
Make clx runnable from anywhere via terminal w/ Go

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@
 The binary name for `circumflex` is `clx`.
 
 #### Package managers
-```console
+```bash
 # Homebrew
 brew install circumflex
 
@@ -64,9 +64,21 @@ yay -S circumflex
 
 #### From source
 
-```console
+- (Go) For testing or development use
+```bash
 # Go
 go run main.go
+```
+- (Go) Exporting as a terminal application
+```bash
+# (as a terminal app)
+go build -o clx main.go
+
+# For all users (requires sudo)
+sudo mv clx /usr/local/bin/
+
+# OR for current user only
+mv clx ~/.local/bin/
 ```
 
 > [!IMPORTANT] 


### PR DESCRIPTION
This PR updates the README to include detailed installation instructions for the `clx` binary:

- Adds steps for exporting from source using `go build`
- Adds instructions for building and exporting the binary for global terminal use via `/usr/local/bin` or `~/.local/bin`

This improves developer experience and makes it easier for users to run the app directly from the terminal.
