### PR TITLE
Add support for xdg-open on FreeBSD, OpenBSD, and NetBSD

### DIFF
--- a/browser/browser.go
+++ b/browser/browser.go
@@ -20,7 +20,7 @@ func Open(url string) {
 	}
 
 	switch runtime.GOOS {
-	case "linux":
+	case "linux", "freebsd", "openbsd", "netbsd":
 		cmd := exec.Command("xdg-open", url)
 		_ = cmd.Start()
 


### PR DESCRIPTION
This PR extends URL opening support on BSD platforms by treating FreeBSD, OpenBSD, and NetBSD the same way as Linux.

Tested on FreeBSD and confirmed xdg-open behavior matches Linux.