### PR TITLE
Add o/c bindings and ^o back-key to reader and comment views

### DIFF
--- a/help/info.go
+++ b/help/info.go
@@ -43,10 +43,14 @@ func ReaderText(screenWidth int) string {
 	nav.addKey("g, G", "Top / bottom")
 	nav.addKey("n, N", "Next / prev section")
 
+	open := keys.addSection("Open")
+	open.addKey("o", "Open story in browser")
+	open.addKey("c", "Open comments in browser")
+
 	app := keys.addSection("App")
 	app.color = style.HeaderTertiary()
 	app.addKey("i, ?", "Help")
-	app.addKey("q, ⎋", "Back")
+	app.addKey("q, ⎋, ^o", "Back")
 
 	return formatKeymaps(keys, screenWidth)
 }
@@ -64,8 +68,11 @@ func CommentText(screenWidth int, enableNerdFonts bool) string {
 	read.addKey("↩", "Toggle all")
 	read.addKey("⇥", "Navigate mode")
 	read.addBreak()
+	read.addKey("o", "Open story in browser")
+	read.addKey("c", "Open comments in browser")
+	read.addBreak()
 	read.addKey("i, ?", "Help")
-	read.addKey("q, ⎋", "Back")
+	read.addKey("q, ⎋, ^o", "Back")
 
 	nav := keys.addSection("Navigate Mode")
 	nav.addKey("j, k", "Next / prev comment")
@@ -75,8 +82,11 @@ func CommentText(screenWidth int, enableNerdFonts bool) string {
 	nav.addKey("↩", "Toggle collapse")
 	nav.addKey("⇥", "Read mode")
 	nav.addBreak()
+	nav.addKey("o", "Open story in browser")
+	nav.addKey("c", "Open comments in browser")
+	nav.addBreak()
 	nav.addKey("i, ?", "Help")
-	nav.addKey("q, ⎋", "Back")
+	nav.addKey("q, ⎋, ^o", "Back")
 
 	legend := keys.addSection("Legend")
 	legend.addLabel(style.CommentOP(labelText("OP", enableNerdFonts)), "Original Poster")

--- a/view/comments/comments.go
+++ b/view/comments/comments.go
@@ -1,14 +1,17 @@
 package comments
 
 import (
+	"context"
 	"fmt"
 	"slices"
 	"strings"
 
 	"github.com/bensadeh/circumflex/ansi"
+	"github.com/bensadeh/circumflex/browser"
 	"github.com/bensadeh/circumflex/comment"
 	"github.com/bensadeh/circumflex/header"
 	"github.com/bensadeh/circumflex/help"
+	"github.com/bensadeh/circumflex/hn"
 	"github.com/bensadeh/circumflex/layout"
 	"github.com/bensadeh/circumflex/meta"
 	"github.com/bensadeh/circumflex/scrollbar"
@@ -194,6 +197,14 @@ func (m *Model) handleKeyPress(msg tea.KeyPressMsg) tea.Cmd {
 		return nil
 	}
 
+	if key.Matches(msg, m.keymap.OpenLink) {
+		return m.openStoryInBrowser()
+	}
+
+	if key.Matches(msg, m.keymap.OpenComments) {
+		return m.openCommentsInBrowser()
+	}
+
 	if key.Matches(msg, m.keymap.ToggleMode) {
 		m.toggleMode()
 
@@ -377,6 +388,33 @@ func (m *Model) footerSeparator() string {
 	}
 
 	return s.Render(strings.Repeat(" ", m.rc.screenWidth))
+}
+
+func (m *Model) openStoryInBrowser() tea.Cmd {
+	url := m.rc.story.URL
+	if url == "" {
+		url = hn.ItemURL(m.rc.story.ID)
+	}
+
+	return func() tea.Msg {
+		if err := browser.Open(context.Background(), url); err != nil {
+			return message.BrowserOpenFailed{Err: err}
+		}
+
+		return nil
+	}
+}
+
+func (m *Model) openCommentsInBrowser() tea.Cmd {
+	url := hn.ItemURL(m.rc.story.ID)
+
+	return func() tea.Msg {
+		if err := browser.Open(context.Background(), url); err != nil {
+			return message.BrowserOpenFailed{Err: err}
+		}
+
+		return nil
+	}
 }
 
 func (m *Model) modeIndicator() string {

--- a/view/comments/keymap.go
+++ b/view/comments/keymap.go
@@ -26,6 +26,9 @@ type keyMap struct {
 
 	Help key.Binding
 
+	OpenLink     key.Binding
+	OpenComments key.Binding
+
 	// Shared between modes: collapse/expand all in scroll, individual in navigate.
 	NextComment    key.Binding
 	PrevComment    key.Binding
@@ -37,8 +40,8 @@ type keyMap struct {
 func defaultKeyMap() keyMap {
 	return keyMap{
 		Quit: key.NewBinding(
-			key.WithKeys("q", "esc"),
-			key.WithHelp("q/esc", "back"),
+			key.WithKeys("q", "esc", "ctrl+o"),
+			key.WithHelp("q/esc/^o", "back"),
 		),
 		Help: key.NewBinding(
 			key.WithKeys("i", "?"),
@@ -99,6 +102,14 @@ func defaultKeyMap() keyMap {
 		ToggleCollapse: key.NewBinding(
 			key.WithKeys("enter"),
 			key.WithHelp("enter", "toggle collapse"),
+		),
+		OpenLink: key.NewBinding(
+			key.WithKeys("o"),
+			key.WithHelp("o", "open story in browser"),
+		),
+		OpenComments: key.NewBinding(
+			key.WithKeys("c"),
+			key.WithHelp("c", "open comments in browser"),
 		),
 	}
 }

--- a/view/reader/keymap.go
+++ b/view/reader/keymap.go
@@ -13,13 +13,15 @@ type keyMap struct {
 	HalfPageUp   key.Binding
 	PageDown     key.Binding
 	PageUp       key.Binding
+	OpenLink     key.Binding
+	OpenComments key.Binding
 }
 
 func defaultKeyMap() keyMap {
 	return keyMap{
 		Quit: key.NewBinding(
-			key.WithKeys("q", "esc"),
-			key.WithHelp("q/esc", "back"),
+			key.WithKeys("q", "esc", "ctrl+o"),
+			key.WithHelp("q/esc/^o", "back"),
 		),
 		Help: key.NewBinding(
 			key.WithKeys("i", "?"),
@@ -56,6 +58,14 @@ func defaultKeyMap() keyMap {
 		PageUp: key.NewBinding(
 			key.WithKeys("pgup", "b"),
 			key.WithHelp("b", "page up"),
+		),
+		OpenLink: key.NewBinding(
+			key.WithKeys("o"),
+			key.WithHelp("o", "open story in browser"),
+		),
+		OpenComments: key.NewBinding(
+			key.WithKeys("c"),
+			key.WithHelp("c", "open comments in browser"),
 		),
 	}
 }

--- a/view/reader/reader.go
+++ b/view/reader/reader.go
@@ -1,13 +1,16 @@
 package reader
 
 import (
+	"context"
 	"slices"
 	"strings"
 
 	"github.com/bensadeh/circumflex/ansi"
 	"github.com/bensadeh/circumflex/article"
+	"github.com/bensadeh/circumflex/browser"
 	"github.com/bensadeh/circumflex/header"
 	"github.com/bensadeh/circumflex/help"
+	"github.com/bensadeh/circumflex/hn"
 	"github.com/bensadeh/circumflex/layout"
 	"github.com/bensadeh/circumflex/meta"
 	"github.com/bensadeh/circumflex/scrollbar"
@@ -280,6 +283,14 @@ func (m *Model) handleKeyPress(msg tea.KeyPressMsg) tea.Cmd {
 		return nil
 	}
 
+	if key.Matches(msg, m.keymap.OpenLink) {
+		return m.openStoryInBrowser()
+	}
+
+	if key.Matches(msg, m.keymap.OpenComments) {
+		return m.openCommentsInBrowser()
+	}
+
 	before := m.viewport.YOffset()
 
 	var cmd tea.Cmd
@@ -372,6 +383,33 @@ func (m *Model) pageUp() {
 
 func (m *Model) gotoBottom() {
 	m.viewport.SetYOffset(max(0, m.contentLines-m.viewportHeight))
+}
+
+func (m *Model) openStoryInBrowser() tea.Cmd {
+	url := m.articleMeta.URL
+	if url == "" {
+		url = hn.ItemURL(m.articleMeta.ID)
+	}
+
+	return func() tea.Msg {
+		if err := browser.Open(context.Background(), url); err != nil {
+			return message.BrowserOpenFailed{Err: err}
+		}
+
+		return nil
+	}
+}
+
+func (m *Model) openCommentsInBrowser() tea.Cmd {
+	url := hn.ItemURL(m.articleMeta.ID)
+
+	return func() tea.Msg {
+		if err := browser.Open(context.Background(), url); err != nil {
+			return message.BrowserOpenFailed{Err: err}
+		}
+
+		return nil
+	}
 }
 
 func (m *Model) jumpToHeader(direction int) {


### PR DESCRIPTION
> Hello there, thanks for the great project! This PR contains some UX improvements over the shortcuts exposed in the app. It was AI generated, I had a second look and it looks clean. I've heavily testing locally and the build is running great. Hope this can make it upstream 🙏

## Summary

In the main list view, `o` opens the highlighted story in the browser and `c` opens the HN comments page. Once you drill into the **comment view** or **reader mode**, those bindings disappear — you have to back out to the list to reach the same URLs.

This PR makes them available everywhere they make sense, plus adds a vim-style `Ctrl+O` back-key in the drilled-in views.

## Changes

- **Reader mode**
  - `o` — open the story URL (falls back to `hn.ItemURL(ID)` for self-posts with no external link)
  - `c` — open the HN comments page
  - `Ctrl+O` — joins `q` / `Esc` as a back-key
- **Comment view** (both Read and Navigate modes)
  - Same `o` / `c` / `Ctrl+O` bindings
- **Help screens** — updated so the new bindings appear in the in-app keymap reference (`i` / `?`)

The reader pulls the URL from `articleMeta.URL` (already present on `reader.Meta`); the comment view uses `m.rc.story.URL` and `m.rc.story.ID`. Same browser invocation path as the existing list-view handlers — no new dependencies.

## Test plan

- [x] \`go build ./...\` — passes
- [x] \`go test ./...\` — 489 tests passing across 35 packages
- [x] Manual: from list, press \`Enter\` to enter comments, then \`o\` → article opens; \`c\` → HN comments page opens; \`Ctrl+O\` → back to list
- [x] Manual: from list, press \`Space\` for reader mode, then \`o\` / \`c\` / \`Ctrl+O\` — same behavior
- [x] Manual: comment view's Navigate mode (\`Tab\`) — \`o\` / \`c\` / \`Ctrl+O\` still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)