### PR TITLE
Add nix flake as an installation option

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,3 +26,41 @@ jobs:
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  update-gomod2nix:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Check tag is on main
+        run: |
+          git fetch origin main
+          if ! git merge-base --is-ancestor "$GITHUB_SHA" origin/main; then
+            echo "Tag is not on main branch, skipping gomod2nix update"
+            exit 1
+          fi
+
+      - uses: actions/setup-go@v6
+        with:
+          go-version: stable
+
+      - name: Install Nix
+        uses: cachix/install-nix-action@v31
+
+      - name: Update gomod2nix.toml
+        run: |
+          nix run github:nix-community/gomod2nix
+          git add gomod2nix.toml
+
+      - name: Run flake checks
+        run: nix flake check
+
+      - name: Commit gomod2nix.toml
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git diff --cached --quiet || git commit -m "Update gomod2nix.toml"
+          git push origin HEAD:main

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@
 .DS_Store
 .idea/
 dist/
+
+# Nix
+/result

--- a/README.md
+++ b/README.md
@@ -33,8 +33,11 @@ The binary name for `circumflex` is `clx`.
 # Homebrew
 brew install circumflex
 
-# Nix
+# Nix (nixpkgs)
 nix-shell -p circumflex
+
+# Nix (flake)
+nix run github:bensadeh/circumflex
 
 # AUR
 yay -S circumflex
@@ -44,6 +47,45 @@ go install github.com/bensadeh/circumflex/cmd/clx@latest
 
 # From source
 go run ./cmd/clx
+```
+
+### Nix Flake
+
+`circumflex` provides a Nix flake with a package, overlay, and home-manager module.
+
+**Add to your flake inputs:**
+
+```nix
+inputs.circumflex = {
+  url = "github:bensadeh/circumflex";
+  inputs.nixpkgs.follows = "nixpkgs";
+};
+```
+
+**Use the package directly:**
+
+```nix
+home.packages = [
+  inputs.circumflex.packages.${system}.default
+];
+```
+
+**Or use the overlay:**
+
+```nix
+nixpkgs.overlays = [ inputs.circumflex.overlays.default ];
+
+# Then pkgs.circumflex is available
+```
+
+**Or use the home-manager module:**
+
+```nix
+imports = [ inputs.circumflex.homeManagerModules.default ];
+```
+
+```nix
+programs.circumflex.enable = true;
 ```
 
 ## Features

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,103 @@
+{
+  "nodes": {
+    "flake-parts": {
+      "inputs": {
+        "nixpkgs-lib": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1778716662,
+        "narHash": "sha256-m1Yf0wZ8j1OHjTc2UwHwyQRSnNeSgLJOd7q5Y45hzi4=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "f7c1a2d347e4c52d5fb8d10cb4d94b5884e546fb",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "gomod2nix": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1770585520,
+        "narHash": "sha256-yBz9Ozd5Wb56i3e3cHZ8WcbzCQ9RlVaiW18qDYA/AzA=",
+        "owner": "nix-community",
+        "repo": "gomod2nix",
+        "rev": "1201ddd1279c35497754f016ef33d5e060f3da8d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "gomod2nix",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1780749050,
+        "narHash": "sha256-3av0pIjlOWQ6rDbNOmpUSvbNnJkGORQKKjb4LtCZsIY=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "a799d3e3886da994fa307f817a6bc705ae538eeb",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-parts": "flake-parts",
+        "gomod2nix": "gomod2nix",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,100 @@
+{
+  description = "Circumflex - Hacker News in your terminal";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    flake-parts = {
+      url = "github:hercules-ci/flake-parts";
+      inputs.nixpkgs-lib.follows = "nixpkgs";
+    };
+    gomod2nix = {
+      url = "github:nix-community/gomod2nix";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+  };
+
+  outputs = inputs @ {
+    self,
+    nixpkgs,
+    flake-parts,
+    ...
+  }:
+    flake-parts.lib.mkFlake {inherit inputs;} {
+      systems = ["x86_64-linux" "aarch64-linux" "x86_64-darwin" "aarch64-darwin"];
+
+      flake = {
+        homeManagerModules.default = import ./nix/home-manager.nix {
+          inherit self;
+          lib = nixpkgs.lib;
+        };
+
+        overlays.default = final: prev: let
+          gomod2nix = inputs.gomod2nix.legacyPackages.${prev.stdenv.hostPlatform.system};
+        in {
+          circumflex = final.callPackage ./nix/package.nix {
+            inherit (gomod2nix) buildGoApplication;
+          };
+        };
+      };
+
+      perSystem = {
+        pkgs,
+        system,
+        self',
+        ...
+      }: let
+        gomod2nix = inputs.gomod2nix.legacyPackages.${system};
+      in {
+        packages.default = pkgs.callPackage ./nix/package.nix {
+          inherit (gomod2nix) buildGoApplication;
+        };
+
+        checks = {
+          package = self'.packages.default;
+
+          formatting = pkgs.runCommand "check-formatting" {} ''
+            ${pkgs.alejandra}/bin/alejandra --check ${self} > $out
+          '';
+
+          home-manager-module = let
+            eval = inputs.nixpkgs.lib.evalModules {
+              modules = [
+                self.homeManagerModules.default
+                {
+                  options.home.packages = inputs.nixpkgs.lib.mkOption {
+                    type = inputs.nixpkgs.lib.types.listOf inputs.nixpkgs.lib.types.package;
+                    default = [];
+                  };
+                }
+                {config.programs.circumflex.enable = true;}
+              ];
+              specialArgs = {inherit pkgs;};
+            };
+          in
+            pkgs.runCommand "check-home-manager-module" {} ''
+              echo "Module evaluates successfully with ${builtins.toString (builtins.length eval.config.home.packages)} packages"
+              touch $out
+            '';
+
+          overlay = let
+            overlayPkgs = import inputs.nixpkgs {
+              localSystem = system;
+              overlays = [self.overlays.default];
+            };
+          in
+            overlayPkgs.circumflex;
+        };
+
+        formatter = pkgs.alejandra;
+
+        devShells.default = pkgs.mkShell {
+          buildInputs = [
+            pkgs.go
+            pkgs.golangci-lint
+            pkgs.goreleaser
+            gomod2nix.gomod2nix
+          ];
+        };
+      };
+    };
+}

--- a/gomod2nix.toml
+++ b/gomod2nix.toml
@@ -1,0 +1,198 @@
+schema = 3
+
+[mod]
+  [mod.'charm.land/bubbles/v2']
+    version = 'v2.1.0'
+    hash = 'sha256-2OmqpBrl+taOJzAhVM6OReLmoYRxZOXx9JqFNjQjsPA='
+
+  [mod.'charm.land/bubbletea/v2']
+    version = 'v2.0.7'
+    hash = 'sha256-YOkvKUahFMMytHXr3AAABDifBtHt29930obiu/kx1vA='
+
+  [mod.'charm.land/glamour/v2']
+    version = 'v2.0.0'
+    hash = 'sha256-CZYlNGw2MihqnSHf1Xxqz55NnqW9fVpLxyvLItryIw4='
+
+  [mod.'charm.land/lipgloss/v2']
+    version = 'v2.0.3'
+    hash = 'sha256-/RFkSUscU3NwymzT+PfizGf3XyQIdVGQlX7vxktCUGk='
+
+  [mod.'codeberg.org/readeck/go-readability/v2']
+    version = 'v2.1.1'
+    hash = 'sha256-g0JCqWYRtdJUkBdCjGe33gr1Q51QYUvQtXv4U4slQ7I='
+
+  [mod.'github.com/BurntSushi/toml']
+    version = 'v1.6.0'
+    hash = 'sha256-ptdUJvuc21ixeLt+M5way/na3aCnCO4MYHWulWp8NEY='
+
+  [mod.'github.com/JohannesKaufmann/dom']
+    version = 'v0.3.1'
+    hash = 'sha256-u0b1MPvNVANlremXNnJ7bWT0VDiiDFh/a62DQPu/cdw='
+
+  [mod.'github.com/JohannesKaufmann/html-to-markdown/v2']
+    version = 'v2.5.2'
+    hash = 'sha256-Ay2ICo+zhVDLX8fpAfc+8/YrLGRCD9swDjAQHiA9+Eg='
+
+  [mod.'github.com/alecthomas/chroma/v2']
+    version = 'v2.26.1'
+    hash = 'sha256-xrxMUQQSkoPnF1OjjwRB8eM9mpopWSYr47t1WcncbKc='
+
+  [mod.'github.com/andybalholm/cascadia']
+    version = 'v1.3.4'
+    hash = 'sha256-CpXE/C+gW7V8MXREZguszzAQumizrCXGTdDRPBaflCs='
+
+  [mod.'github.com/araddon/dateparse']
+    version = 'v0.0.0-20210429162001-6b43995a97de'
+    hash = 'sha256-UuX84naeRGMsFOgIgRoBHG5sNy1CzBkWPKmd6VbLwFw='
+
+  [mod.'github.com/aymerick/douceur']
+    version = 'v0.2.0'
+    hash = 'sha256-NiBX8EfOvLXNiK3pJaZX4N73YgfzdrzRXdiBFe3X3sE='
+
+  [mod.'github.com/bobesa/go-domain-util']
+    version = 'v0.0.0-20250410211237-17ab3b2f4a95'
+    hash = 'sha256-CBakbZB4e884CbP0CZAM7xetE5zSgQcZx2rI4rYo/VY='
+
+  [mod.'github.com/charmbracelet/colorprofile']
+    version = 'v0.4.3'
+    hash = 'sha256-y+QDUxGOKhugEMQLRUTZYT2C+wKqYHnMLJ44jbh7+JA='
+
+  [mod.'github.com/charmbracelet/ultraviolet']
+    version = 'v0.0.0-20260608091853-35bcb7319efa'
+    hash = 'sha256-2B5IktzT4KUjWX2GpfJ7j3idXbxNAwUtyNRKAXhxebg='
+
+  [mod.'github.com/charmbracelet/x/ansi']
+    version = 'v0.11.7'
+    hash = 'sha256-q8BZJq4K7NE5ETocN9/G/EoV0dUyD703ONSfHiUYzWQ='
+
+  [mod.'github.com/charmbracelet/x/exp/slice']
+    version = 'v0.0.0-20260608090822-c3ad58c6c9e5'
+    hash = 'sha256-bMsbEzP1gHA2OJx4zMYZUI3UFhcTG+mcFm8rRY+Khh8='
+
+  [mod.'github.com/charmbracelet/x/term']
+    version = 'v0.2.2'
+    hash = 'sha256-KF7IU1Luxl/sZP6XjomWB2e3lxSUS4/5AahhapGir/4='
+
+  [mod.'github.com/charmbracelet/x/termios']
+    version = 'v0.1.1'
+    hash = 'sha256-sri3LpHCBhGvnJldDzBxwbbZpeSGZVCJFOUL45uBFds='
+
+  [mod.'github.com/charmbracelet/x/windows']
+    version = 'v0.2.2'
+    hash = 'sha256-CvmE8kAC5wlPSeWjl2hc5xizvGS2FeOLHw84froldkk='
+
+  [mod.'github.com/clipperhouse/displaywidth']
+    version = 'v0.11.0'
+    hash = 'sha256-WokyTaofEy95xlshqK5YDzpemhXV5oaQifxS9YyfCXo='
+
+  [mod.'github.com/clipperhouse/uax29/v2']
+    version = 'v2.7.0'
+    hash = 'sha256-GO3az7WiGcwU0OvmocwdfR5ohGRL8NbjscIaMyhAdxE='
+
+  [mod.'github.com/davecgh/go-spew']
+    version = 'v1.1.1'
+    hash = 'sha256-nhzSUrE1fCkN0+RL04N4h8jWmRFPPPWbCuDc7Ss0akI='
+
+  [mod.'github.com/dlclark/regexp2/v2']
+    version = 'v2.2.1'
+    hash = 'sha256-kd7GO+bExbWUNCZXtX/zwG4pn2ZYEYuEfIR2KfTHqMQ='
+
+  [mod.'github.com/go-shiori/dom']
+    version = 'v0.0.0-20230515143342-73569d674e1c'
+    hash = 'sha256-4lm9KZfR2XnfZU9KTG+4jqLYZqbfL74AMO4y3dKpIbg='
+
+  [mod.'github.com/gogs/chardet']
+    version = 'v0.0.0-20211120154057-b7413eaefb8f'
+    hash = 'sha256-4MeqBJsh4U+ZEbfdDwdciTYMlQWkCil2KJbUxHjBSIo='
+
+  [mod.'github.com/gorilla/css']
+    version = 'v1.0.1'
+    hash = 'sha256-6JwNHqlY2NpZ0pSQTyYPSpiNqjXOdFHqrUT10sv3y8A='
+
+  [mod.'github.com/inconshreveable/mousetrap']
+    version = 'v1.1.0'
+    hash = 'sha256-XWlYH0c8IcxAwQTnIi6WYqq44nOKUylSWxWO/vi+8pE='
+
+  [mod.'github.com/kr/pretty']
+    version = 'v0.1.0'
+    hash = 'sha256-Fx+TaNrxW0VfzonT2jnd5MU09RRz7GJZkqAtJR6/pKI='
+
+  [mod.'github.com/lucasb-eyer/go-colorful']
+    version = 'v1.4.0'
+    hash = 'sha256-i/3GDHKEMLCy0kc3mtyk58UWYOPmKoUVaq6QCAWXKP0='
+
+  [mod.'github.com/mattn/go-runewidth']
+    version = 'v0.0.24'
+    hash = 'sha256-t2uvZkmlTXQCj76p4poI9y82iziJX2lF44UhkLgLN40='
+
+  [mod.'github.com/microcosm-cc/bluemonday']
+    version = 'v1.0.27'
+    hash = 'sha256-EZSya9FLPQ83CL7N2cZy21fdS35hViTkiMK5f3op8Es='
+
+  [mod.'github.com/muesli/cancelreader']
+    version = 'v0.2.2'
+    hash = 'sha256-uEPpzwRJBJsQWBw6M71FDfgJuR7n55d/7IV8MO+rpwQ='
+
+  [mod.'github.com/pmezard/go-difflib']
+    version = 'v1.0.0'
+    hash = 'sha256-/FtmHnaGjdvEIKAJtrUfEhV7EVo5A/eYrtdnUkuxLDA='
+
+  [mod.'github.com/rivo/uniseg']
+    version = 'v0.4.7'
+    hash = 'sha256-rDcdNYH6ZD8KouyyiZCUEy8JrjOQoAkxHBhugrfHjFo='
+
+  [mod.'github.com/spf13/cobra']
+    version = 'v1.10.2'
+    hash = 'sha256-nbRCTFiDCC2jKK7AHi79n7urYCMP5yDZnWtNVJrDi+k='
+
+  [mod.'github.com/spf13/pflag']
+    version = 'v1.0.10'
+    hash = 'sha256-uDPnWjHpSrzXr17KEYEA1yAbizfcsfo5AyztY2tS6ZU='
+
+  [mod.'github.com/stretchr/testify']
+    version = 'v1.11.1'
+    hash = 'sha256-sWfjkuKJyDllDEtnM8sb/pdLzPQmUYWYtmeWz/5suUc='
+
+  [mod.'github.com/xo/terminfo']
+    version = 'v0.0.0-20220910002029-abceb7e1c41e'
+    hash = 'sha256-GyCDxxMQhXA3Pi/TsWXpA8cX5akEoZV7CFx4RO3rARU='
+
+  [mod.'github.com/yuin/goldmark']
+    version = 'v1.8.2'
+    hash = 'sha256-LoWfW1Tb6mNuMR7SoA/4SJv4pTKfsVXqeXEVm4uEQ7Q='
+
+  [mod.'github.com/yuin/goldmark-emoji']
+    version = 'v1.0.6'
+    hash = 'sha256-+d6bZzOPE+JSFsZbQNZMCWE+n3jgcQnkPETVk47mxSY='
+
+  [mod.'golang.org/x/net']
+    version = 'v0.55.0'
+    hash = 'sha256-Phi2mSmBGOJcvqPPAit3uqF3UP8SKRI9dHj6yTM3s5s='
+
+  [mod.'golang.org/x/sync']
+    version = 'v0.21.0'
+    hash = 'sha256-2n7PVb1krz7UpnXYGVmCrxV0fZBnjQdVVt6eVudEPYY='
+
+  [mod.'golang.org/x/sys']
+    version = 'v0.46.0'
+    hash = 'sha256-NzRXMSEk6upeudJvUEPVnw6clJ3d8UdC/vdfANWAc8g='
+
+  [mod.'golang.org/x/term']
+    version = 'v0.43.0'
+    hash = 'sha256-gFV1oGgs/vpRamvDWmu93voN57iyZMk/hh+oL8L9VrQ='
+
+  [mod.'golang.org/x/text']
+    version = 'v0.37.0'
+    hash = 'sha256-8XDOnlPIybcDRy89fkjG5VqtIt5Ku+LmaqYhgKl7i1E='
+
+  [mod.'gopkg.in/check.v1']
+    version = 'v1.0.0-20190902080502-41f04d3bba15'
+    hash = 'sha256-Xl5gjoqU26M+Yxm6Xok5VHVpYT5hItwsN7d2Wj9L020='
+
+  [mod.'gopkg.in/yaml.v3']
+    version = 'v3.0.1'
+    hash = 'sha256-FqL9TKYJ0XkNwJFnq9j0VvJ5ZUU1RvH/52h/f5bkYAU='
+
+  [mod.'resty.dev/v3']
+    version = 'v3.0.0-rc.1'
+    hash = 'sha256-vu71VeRlhA73XqZki9rmVsUMD8Tw5oA0nh4Hz+gjYv8='

--- a/nix/home-manager.nix
+++ b/nix/home-manager.nix
@@ -1,0 +1,21 @@
+{
+  self,
+  lib,
+  ...
+}: {
+  config,
+  pkgs,
+  ...
+}: let
+  cfg = config.programs.circumflex;
+in {
+  options.programs.circumflex = {
+    enable = lib.mkEnableOption "Circumflex - Hacker News in your terminal";
+
+    package = lib.mkPackageOption self.packages.${pkgs.stdenv.hostPlatform.system} "default" {};
+  };
+
+  config = lib.mkIf cfg.enable {
+    home.packages = [cfg.package];
+  };
+}

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -1,0 +1,24 @@
+{
+  lib,
+  buildGoApplication,
+}:
+buildGoApplication {
+  pname = "circumflex";
+  version = "4.4-dev";
+  src = lib.cleanSourceWith {
+    src = ./..;
+    filter = path: type:
+      (lib.hasSuffix ".go" path)
+      || (lib.hasSuffix ".mod" path)
+      || (type == "directory");
+  };
+  modules = ../gomod2nix.toml;
+  doCheck = false;
+
+  meta = {
+    description = "It's Hacker News in your terminal";
+    homepage = "https://github.com/bensadeh/circumflex";
+    license = lib.licenses.mit;
+    mainProgram = "circumflex";
+  };
+}


### PR DESCRIPTION
## Description

This allows users to both get access to the toolchain required to build everything locally as well as allow nix users to use this flake in their setups.

- Add `update-gomod2nix` step to `.github/workflows/release.yml` to update the `gomod2nix.toml` which updates the flake. It also runs `nix flake check` which are basically nix tests
- Add flake.nix and related files
-  Add documentation - this gives various examples of how the flake can be used