### PR TITLE
docs: fix Title Case heading and Oxford comma in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
   <img src="screenshots/main-view.png" alt="Main view"/>
 </p>
 
-### Main features
+### Main Features
 
 - 🛋 **Everything in one place** — read both the comment section and articles in Reader Mode
 - 🌈 **Syntax highlighting** — syntax-aware formatting for comments and headlines
@@ -68,7 +68,7 @@ In `navigate mode`, you can individually select comments and collapse specific t
 </p>
 
 
-`circumflex` is read-only and does not support logging in, voting or commenting.
+`circumflex` is read-only and does not support logging in, voting, or commenting.
 
 ### Reader Mode
 


### PR DESCRIPTION
## Description
This PR fixes section heading Title Case and list comma consistency in `README.md`.

## Details
1. Capitalized section header (`### Main features` -> `### Main Features`).
2. Added Oxford comma (`logging in, voting or commenting` -> `logging in, voting, or commenting`).